### PR TITLE
fix: corrigir problema de cache na atualizaÃ§Ã£o de KM das vans

### DIFF
--- a/pages/api/vans/list.ts
+++ b/pages/api/vans/list.ts
@@ -1,20 +1,28 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import admin from '../../../lib/firebaseAdmin';
 
-// Cache simples em memória
-let cache: any = null;
-let cacheTime = 0;
-const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 horas
+// Cache global compartilhado
+if (typeof global !== 'undefined') {
+  if (!(global as any).vansCache) {
+    (global as any).vansCache = null;
+    (global as any).vansCacheTime = 0;
+  }
+}
+
+const CACHE_DURATION = 5 * 60 * 1000; // 5 minutos (reduzido para melhor responsividade)
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  // Verificar cache
+  // Verificar cache global
   const now = Date.now();
-  if (cache && (now - cacheTime) < CACHE_DURATION) {
-    return res.status(200).json(cache);
+  const globalCache = (global as any).vansCache;
+  const globalCacheTime = (global as any).vansCacheTime;
+  
+  if (globalCache && (now - globalCacheTime) < CACHE_DURATION) {
+    return res.status(200).json(globalCache);
   }
 
   try {
@@ -32,9 +40,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }))
       .sort((a: any, b: any) => a.placa.localeCompare(b.placa));
 
-    // Atualizar cache
-    cache = vans;
-    cacheTime = now;
+    // Atualizar cache global
+    (global as any).vansCache = vans;
+    (global as any).vansCacheTime = now;
 
     res.status(200).json(vans);
   } catch (error: any) {

--- a/pages/api/vans/update-km.ts
+++ b/pages/api/vans/update-km.ts
@@ -1,6 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import admin from '../../../lib/firebaseAdmin';
 
+// Função para invalidar cache de vans
+function invalidateVansCache() {
+  // Limpar cache global se existir
+  if (typeof global !== 'undefined' && (global as any).vansCache) {
+    (global as any).vansCache = null;
+    (global as any).vansCacheTime = 0;
+  }
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'PUT') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -18,6 +27,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await db.collection('vans').doc(id).update({
       kmAtual: parseInt(kmAtual)
     });
+
+    // Invalidar cache de vans para forçar atualização
+    invalidateVansCache();
 
     res.status(200).json({ message: 'KM atualizado com sucesso' });
   } catch (error: any) {

--- a/pages/api/vans/update-placa.ts
+++ b/pages/api/vans/update-placa.ts
@@ -1,6 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import admin from '../../../lib/firebaseAdmin';
 
+// Função para invalidar cache de vans
+function invalidateVansCache() {
+  // Limpar cache global se existir
+  if (typeof global !== 'undefined' && (global as any).vansCache) {
+    (global as any).vansCache = null;
+    (global as any).vansCacheTime = 0;
+  }
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'PUT') {
     return res.status(405).json({ error: 'Method not allowed' });
@@ -18,6 +27,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await db.collection('vans').doc(id).update({
       placa: placa
     });
+
+    // Invalidar cache de vans para forçar atualização
+    invalidateVansCache();
 
     res.status(200).json({ success: true });
   } catch (error) {


### PR DESCRIPTION
* Reduzir o tempo de cache da API de listagem de vans de 24 horas para 5 minutos.
* Implementar cache global compartilhado entre todas as APIs.
* Adicionar invalidação automática do cache nas APIs de atualização.
* Garantir que alterações em KM e placa sejam refletidas imediatamente na interface.

**Resultado:** resolve o problema em que atualizações de KM não eram exibidas devido ao cache de longa duração.
